### PR TITLE
add sameCols() and tests

### DIFF
--- a/artools/artools.py
+++ b/artools/artools.py
@@ -50,6 +50,10 @@ def uniqueRows(A, tol=1e-13):
 
 
 def sameRows(A, B):
+    """
+    Check if A and B have the exact same rows.
+    """
+    
     # check if A and B are the same shape
     if A.shape != B.shape:
         return False
@@ -66,6 +70,14 @@ def sameRows(A, B):
                 return False
 
         return True
+
+
+def sameCols(A, B):
+    """
+    Check if A and B have the exact same columns.
+    """
+
+    return sameRows(A.T, B.T)
 
 
 def plotRegion2D(Vs, ax=None, color="g", alpha=0.5, plot_verts=False):

--- a/artools/test/sameCols_test.py
+++ b/artools/test/sameCols_test.py
@@ -1,0 +1,223 @@
+import sys
+sys.path.append('../')
+from artools import sameCols
+
+import scipy as sp
+
+
+class TestSame:
+
+    def test_1(self):
+        # identical matrices
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        assert (sameCols(A, B) is True)
+
+
+    def test_2(self):
+        # same rows, different order
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = sp.array([[1., 0, 0],
+                      [0, 1, 3],
+                      [0, 1, 2]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_3(self):
+        # 1-D rows
+        A = sp.array([[1., 0, 0]])
+
+        B = sp.array([[1., 0, 0]])
+
+        assert (sameCols(A, B) is True)
+
+
+    def test_4(self):
+        # identical copies
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = A
+
+        assert (sameCols(A, B) is True)
+
+
+class TestElements:
+
+    def test_1(self):
+        # same shape, different elements
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = sp.array([[1., 0, 0],
+                      [1, 0, 0],
+                      [1, 0, 0]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_2(self):
+        # same shape, different elements
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = sp.array([[0., 0, 0],
+                      [0, 0, 0],
+                      [0, 0, 0]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_3(self):
+        # same shape, just transposed
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = A.T
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_4(self):
+        # 0-D numpy arrays, with different elements
+        A = sp.array([1., 0, 0])
+
+        B = sp.array([1, 2, -3])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_5(self):
+        # same shape, just the negative of one another
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = -A
+
+        assert (sameCols(A, B) is False)
+
+
+class TestShape:
+
+    def test_1(self):
+        # different shapes
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = sp.array([[1., 0, 0],
+                      [0, 1, 2]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_2(self):
+        # different shapes
+        A = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        B = sp.array([[1., 0],
+                      [0, 2],
+                      [0, 3]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_3(self):
+        # different shapes
+        A = sp.array([[1., 0],
+                      [0, 1],
+                      [0, 1]])
+
+        B = sp.array([[1., 0, 0],
+                      [0, 1, 2],
+                      [0, 1, 3]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_4(self):
+        # both column vectors, different elements
+        A = sp.array([[1., 0, 0, 0, 0]]).T
+
+        B = sp.array([[1., 0, 0, 1, 0]]).T
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_5(self):
+        # both column vectors, same elements
+        A = sp.array([[1., 2, 3, 4, 5]]).T
+
+        B = sp.array([[1., 2, 3, 4, 5]]).T
+
+        assert (sameCols(A, B) is True)
+
+
+    def test_6(self):
+        # both row vectors, different elements
+        A = sp.array([[1., 0, 0, 0, 0]])
+
+        B = sp.array([[1., 0, 0, 1, 0]])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_7(self):
+        # both row vectors, same elements
+        A = sp.array([[1., 0, 0, 0, 0]])
+
+        B = sp.array([[1., 0, 0, 0, 0]])
+
+        assert (sameCols(A, B) is True)
+
+
+    def test_8(self):
+        # one row vectors, one column vector
+        A = sp.array([[1., 0, 0, 0, 0]])
+
+        B = sp.array([[1., 0, 0, 0, 0]]).T
+
+        assert (sameCols(A, B) is False)
+
+
+class TestArrays:
+
+    def test_1(self):
+        # both 0-D arrays
+        A = sp.array([1., 2, 3, 4, 5])
+        B = sp.array([1., 2, 3, 4, 5])
+
+        assert (sameCols(A, B) is True)
+
+
+    def test_2(self):
+        # A is a row vector, B is a 0-D array
+        A = sp.array([[1., 2, 3, 4, 5]])
+        B = sp.array([1., 2, 3, 4, 5])
+
+        assert (sameCols(A, B) is False)
+
+
+    def test_3(self):
+        # A is a column vector, B is a 0-D array
+        A = sp.array([[1., 2, 3, 4, 5]]).T
+        B = sp.array([1., 2, 3, 4, 5])
+
+        assert (sameCols(A, B) is False)


### PR DESCRIPTION
`artools` contains a `sameRows()` function for checking if two matrices A and B have the same rows, but it's missing a sameCols() function for checking if A and B are equivalent in terms of their columns.