### PR TITLE
Stoich_mat builder

### DIFF
--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1132,8 +1132,6 @@ def genStoichMat(rxn_strings):
     components_dict = genComponentDict(rxn_strings)
     num_rxns = len(rxn_strings)
     num_comps = len(components_dict)
-    #print "\nthere are %i components in %i reactions" % (num_comps, num_rxns)
-    #print rxn_strings
 
     stoich_mat = sp.zeros((num_comps, num_rxns))
     for rnum, rxn_str in enumerate(rxn_strings):
@@ -1141,11 +1139,6 @@ def genStoichMat(rxn_strings):
 
         reactants = [splitCoeffFromStr(term) for term in lhs.split("+")]
         products = [splitCoeffFromStr(term) for term in rhs.split("+")]
-
-        #print "\nreaction %i reactants:" % rnum
-        #print reactants
-        #print "\nreaction %i products:" % rnum
-        #print products
 
         for ri in reactants:
             # reactants have negative reaction coefficients

--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1102,7 +1102,13 @@ def genStoichMat(rxn_strings):
     """
     Generate a stoichiometric coefficient matrix given a list of reactions
     written as Python strings in a specific format.
-    
+
+    '+' indicates separate terms in the reaction string: 'A + B'
+    '*' specifies stoichiometric coefficients: '1.5*A + 3*B'
+    '->' separates products from reactants: '1.5*A + B -> 0.1*C'
+    Organise each line in the reaction as a separate string in a list:
+        ['N2 + 3*H2 -> 2*NH3', '2*H2 + O2 -> 2*H2O']
+
     e.g
     ['A + 2*B -> 1.5*C',
      'A + C -> 0.5*D',

--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1087,11 +1087,32 @@ def genComponentDict(rxn_strings):
 
 
 def genStoichMat(rxn_strings):
-    comps = genComponentDict(rxn_strings)
+    """
+    e.g
+    ['A + 2*B -> 1.5*C',
+     'A + C -> 0.5*D',
+     'C + 3.2*D -> E + 0.1*F']
+
+    returns: [[-1.  -1.   0. ]
+              [-2.   0.   0. ]
+              [ 1.5 -1.  -1. ]
+              [ 0.   0.5 -3.2]
+              [ 0.   0.   1. ]
+              [ 0.   0.   0.1]]
+
+    with dictionary: {'A': 0,
+                      'B': 1,
+                      'C': 2,
+                      'D': 3,
+                      'E': 4,
+                      'F': 5}
+    """
+
+    components_dict = genComponentDict(rxn_strings)
     num_rxns = len(rxn_strings)
-    num_comps = len(comps)
-    print "\nthere are %i components in %i reactions" % (num_comps, num_rxns)
-    print rxn_strings
+    num_comps = len(components_dict)
+    #print "\nthere are %i components in %i reactions" % (num_comps, num_rxns)
+    #print rxn_strings
 
     stoich_mat = sp.zeros((num_comps, num_rxns))
     for rnum, rxn_str in enumerate(rxn_strings):
@@ -1100,16 +1121,16 @@ def genStoichMat(rxn_strings):
         reactants = [splitCoeffFromStr(term) for term in lhs.split("+")]
         products = [splitCoeffFromStr(term) for term in rhs.split("+")]
 
-        print "\nreaction %i reactants:" % rnum
-        print reactants
-        print "\nreaction %i products:" % rnum
-        print products
+        #print "\nreaction %i reactants:" % rnum
+        #print reactants
+        #print "\nreaction %i products:" % rnum
+        #print products
 
         for ri in reactants:
             # reactants have negative reaction coefficients
             coeff = eval(ri[0])*-1
             comp = ri[1]
-            comp_idx = comps[comp]
+            comp_idx = components_dict[comp]
 
             stoich_mat[comp_idx, rnum] = coeff
 
@@ -1117,8 +1138,8 @@ def genStoichMat(rxn_strings):
             # reactants have positive reaction coefficients
             coeff = eval(pi[0])
             comp = pi[1]
-            comp_idx = comps[comp]
+            comp_idx = components_dict[comp]
 
             stoich_mat[comp_idx, rnum] = coeff
 
-    print stoich_mat
+    return stoich_mat

--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1141,7 +1141,7 @@ def genStoichMat(rxn_strings):
         products = [splitCoeffFromStr(term) for term in rhs.split("+")]
 
         for ri in reactants:
-            # reactants have negative reaction coefficients
+            # reactants have negative stoichiometric coefficients
             coeff = eval(ri[0])*-1
             comp = ri[1]
             comp_idx = components_dict[comp]
@@ -1149,7 +1149,7 @@ def genStoichMat(rxn_strings):
             stoich_mat[comp_idx, rnum] = coeff
 
         for pi in products:
-            # reactants have positive reaction coefficients
+            # reactants have positive stoichiometric coefficients
             coeff = eval(pi[0])
             comp = pi[1]
             comp_idx = components_dict[comp]

--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1042,14 +1042,16 @@ def calcDim(Xs):
 
 def splitCoeffFromStr(substring):
     """
-    Convert a substring into a list where the first element is the coefficient
-    an the second element is the component name.
+    Convert a substring into a list where the first element is the reaction
+    coefficient and the second is the component name.
+    Whitespace will also be stripped out from the string.
 
-    e.g. '2*H2O' --> ['2', 'H2O']
-         'H2O' --> ['1', 'H2O']
+    e.g.     '2*H2O' --> ['2', 'H2O']
+               'H2O' --> ['1', 'H2O']
+         ' 2 * H2O ' --> ['2', 'H2O']
     """
-    
-    items = substring.split("*")
+
+    items = [item.strip() for item in substring.split("*")]
     if len(items) > 1:
         return items
 

--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1038,3 +1038,35 @@ def calcDim(Xs):
     Vs = Xs - Xs[0, :]
 
     return rank(Vs)
+
+
+def splitCoeffFromStr(substring):
+    """
+    Convert a substring into a list where the first element is the coefficient
+    an the second element is the component name.
+
+    e.g. '2*H2O' --> ['2', 'H2O']
+         'H2O' --> ['1', 'H2O']
+    """
+    
+    items = substring.split("*")
+    if len(items) > 1:
+        return items
+
+    items.append("1")
+    items.reverse()
+    return items
+
+
+def genStoichMat(rxn_strings):
+    print rxn_strings
+
+    for rxn_str in rxn_strings:
+        terms = rxn_str.strip().split(" ")
+        arrow_pos = terms.index("->")
+
+        lhs_terms = terms[:arrow_pos]
+        rhs_terms = terms[arrow_pos + 1:]
+
+        for t in lhs_terms:
+            print splitCoeffFromStr(t)

--- a/artools/artools.py
+++ b/artools/artools.py
@@ -53,7 +53,7 @@ def sameRows(A, B):
     """
     Check if A and B have the exact same rows.
     """
-    
+
     # check if A and B are the same shape
     if A.shape != B.shape:
         return False
@@ -1100,6 +1100,9 @@ def genComponentDict(rxn_strings):
 
 def genStoichMat(rxn_strings):
     """
+    Generate a stoichiometric coefficient matrix given a list of reactions
+    written as Python strings in a specific format.
+    
     e.g
     ['A + 2*B -> 1.5*C',
      'A + C -> 0.5*D',

--- a/artools/test/genStoichMat_test.py
+++ b/artools/test/genStoichMat_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 sys.path.append('../')
 import artools
@@ -9,6 +10,7 @@ class TestTuple:
 
     def test_1(self):
 
+        # reactions written in tuple format
         rxn_str = ("A -> B",)
 
         A = artools.genStoichMat(rxn_str)
@@ -20,18 +22,7 @@ class TestTuple:
 
 class TestNormal:
 
-    def test_1(self):
-
-        rxn_str = ["A -> B"]
-
-        A = artools.genStoichMat(rxn_str)
-        A_ref = sp.array([[-1.0],
-                          [1.0]])
-
-        assert (artools.sameRows(A.T, A_ref.T) is True)
-
-
-    def test_2(self):
+    def test_vdv3D(self):
 
         rxn_str = ["A -> B",
                    "B -> C",
@@ -42,6 +33,34 @@ class TestNormal:
                           [1, -1, 0],
                           [0, 1, 0],
                           [0, 0, 1]])
+
+        assert (artools.sameRows(A.T, A_ref.T) is True)
+
+
+    def test_BTX(self):
+        rxns = ['B + 0.5*E -> T',
+                'T + 0.5*E -> X',
+                '2*B -> D + H']
+
+        A_ref = sp.array([[-1.0, 0.0, -2.0],
+                          [-0.5, -0.5, 0.0],
+                          [1.0, -1.0, 0.0],
+                          [0.0, 1.0, 0.0],
+                          [0.0, 0.0, 1.0],
+                          [0.0, 0.0, 1.0]])
+
+        A = artools.genStoichMat(rxns)
+
+        assert (artools.sameRows(A, A_ref) is True)
+
+
+    def test_1(self):
+
+        rxn_str = ["A -> B"]
+
+        A = artools.genStoichMat(rxn_str)
+        A_ref = sp.array([[-1.0],
+                          [1.0]])
 
         assert (artools.sameRows(A.T, A_ref.T) is True)
 
@@ -61,3 +80,51 @@ class TestNormal:
                           [0, 0, 0.1]])
 
         assert (artools.sameRows(A.T, A_ref.T) is True)
+
+
+class TestRealistic:
+
+    def test_NH3_1(self):
+        rxn = ["N2 + 3*H2 -> 2*NH3"]
+
+        A_ref = sp.array([[-1.0, -3.0, 2.0]]).T
+        A = artools.genStoichMat(rxn)
+
+        assert (artools.sameRows(A, A_ref) is True)
+
+
+    def test_CH4_reform(self):
+        rxns = ['CH4 + H2O -> CO + 3*H2',
+                'CO + H2O -> CO2 + H2']
+
+        stoich_mat = sp.array([[-1.0, 0.0],
+                               [-1.0, -1.0],
+                               [1.0, -1.0],
+                               [3.0, 1.0],
+                               [0.0, 1.0]])
+        A = artools.genStoichMat(rxns)
+
+        assert (artools.sameRows(stoich_mat, A) is True)
+
+
+    def test_UCG_1(self):
+        rxns = ['C + O2 -> CO2',
+                'C + CO2 -> 2*CO',
+                'CO + 0.5*O2 -> CO2',
+                'C + H2O -> CO + H2',
+                'CO + H2O -> CO2 + H2',
+                'CO2 + H2 -> CO + H2O',
+                'C + 2*H2 -> CH4',
+                'CH4 + H2O -> CO + 3*H2',
+                'CO + 3*H2 -> CH4 + H2O']
+
+        A_ref = sp.array([[-1., -1, 0, -1, 0, 0, -1, 0, 0],
+                          [-1, 0, -0.5, 0, 0, 0, 0, 0, 0],
+                          [1, -1, 1, 0, 1, -1, 0, 0, 0],
+                          [0, 2, -1, 1, -1, 1, 0, 1, -1],
+                          [0, 0, 0, -1, -1, 1, 0, -1, 1],
+                          [0, 0, 0, 1, 1, -1, -2, 3, -3],
+                          [0, 0, 0, 0, 0, 0, 1, -1, 1]])
+        A = artools.genStoichMat(rxns)
+
+        assert (artools.sameRows(A, A_ref) is True)

--- a/artools/test/genStoichMat_test.py
+++ b/artools/test/genStoichMat_test.py
@@ -6,14 +6,46 @@ import artools
 import scipy as sp
 
 
-class TestRand:
+class TestNormal:
 
-    def test_0a(self):
+    def test_1(self):
+
+        rxn_str = ["A -> B"]
+
+        A = artools.genStoichMat(rxn_str)
+        A_ref = sp.array([[-1.0],
+                          [1.0]])
+
+        assert (artools.sameRows(A.T, A_ref.T) is True)
+
+
+    def test_2(self):
 
         rxn_str = ["A -> B",
                    "B -> C",
                    "2*A -> D"]
 
-        artools.genStoichMat(rxn_str)
-        
-        assert True
+        A = artools.genStoichMat(rxn_str)
+        A_ref = sp.array([[-1., 0, -2],
+                          [1, -1, 0],
+                          [0, 1, 0],
+                          [0, 0, 1]])
+
+        assert (artools.sameRows(A.T, A_ref.T) is True)
+
+
+    def test_3(self):
+
+        rxn_str = ['A + 2*B -> 1.5*C',
+                   'A + C -> 0.5*D',
+                   'C + 3.2*D -> E + 0.1*F']
+
+        A = artools.genStoichMat(rxn_str)
+        A_ref = sp.array([[-1., -1, 0],
+                          [-2, 0, 0],
+                          [1.5, -1, -1],
+                          [0, 0.5, -3.2],
+                          [0, 0, 1],
+                          [0, 0, 0.1]])
+
+        assert (artools.sameRows(A.T, A_ref.T) is True)

--- a/artools/test/genStoichMat_test.py
+++ b/artools/test/genStoichMat_test.py
@@ -1,0 +1,19 @@
+import sys
+sys.path.append('../')
+import artools
+#from artools import calcDim, stoichSubspace
+
+import scipy as sp
+
+
+class TestRand:
+
+    def test_0a(self):
+
+        rxn_str = ["A -> B",
+                   "B -> C",
+                   "2*A -> D"]
+
+        artools.genStoichMat(rxn_str)
+        
+        assert True

--- a/artools/test/genStoichMat_test.py
+++ b/artools/test/genStoichMat_test.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import sys
 sys.path.append('../')
 import artools
-#from artools import calcDim, stoichSubspace
+from artools import genStoichMat, sameRows
 
 import scipy as sp
 
@@ -13,11 +13,11 @@ class TestTuple:
         # reactions written in tuple format
         rxn_str = ("A -> B",)
 
-        A = artools.genStoichMat(rxn_str)
+        A = genStoichMat(rxn_str)
         A_ref = sp.array([[-1.0],
                           [1.0]])
 
-        assert (artools.sameRows(A.T, A_ref.T) is True)
+        assert (sameRows(A, A_ref) is True)
 
 
 class TestNormal:
@@ -28,13 +28,13 @@ class TestNormal:
                    "B -> C",
                    "2*A -> D"]
 
-        A = artools.genStoichMat(rxn_str)
+        A = genStoichMat(rxn_str)
         A_ref = sp.array([[-1., 0, -2],
                           [1, -1, 0],
                           [0, 1, 0],
                           [0, 0, 1]])
 
-        assert (artools.sameRows(A.T, A_ref.T) is True)
+        assert (sameRows(A, A_ref) is True)
 
 
     def test_BTX(self):
@@ -49,20 +49,20 @@ class TestNormal:
                           [0.0, 0.0, 1.0],
                           [0.0, 0.0, 1.0]])
 
-        A = artools.genStoichMat(rxns)
+        A = genStoichMat(rxns)
 
-        assert (artools.sameRows(A, A_ref) is True)
+        assert (sameRows(A, A_ref) is True)
 
 
     def test_1(self):
 
         rxn_str = ["A -> B"]
 
-        A = artools.genStoichMat(rxn_str)
+        A = genStoichMat(rxn_str)
         A_ref = sp.array([[-1.0],
                           [1.0]])
 
-        assert (artools.sameRows(A.T, A_ref.T) is True)
+        assert (sameRows(A, A_ref) is True)
 
 
     def test_3(self):
@@ -71,7 +71,7 @@ class TestNormal:
                    'A + C -> 0.5*D',
                    'C + 3.2*D -> E + 0.1*F']
 
-        A = artools.genStoichMat(rxn_str)
+        A = genStoichMat(rxn_str)
         A_ref = sp.array([[-1., -1, 0],
                           [-2, 0, 0],
                           [1.5, -1, -1],
@@ -79,7 +79,7 @@ class TestNormal:
                           [0, 0, 1],
                           [0, 0, 0.1]])
 
-        assert (artools.sameRows(A.T, A_ref.T) is True)
+        assert (sameRows(A, A_ref) is True)
 
 
 class TestRealistic:
@@ -88,9 +88,9 @@ class TestRealistic:
         rxn = ["N2 + 3*H2 -> 2*NH3"]
 
         A_ref = sp.array([[-1.0, -3.0, 2.0]]).T
-        A = artools.genStoichMat(rxn)
+        A = genStoichMat(rxn)
 
-        assert (artools.sameRows(A, A_ref) is True)
+        assert (sameRows(A, A_ref) is True)
 
 
     def test_CH4_reform(self):
@@ -102,9 +102,9 @@ class TestRealistic:
                                [1.0, -1.0],
                                [3.0, 1.0],
                                [0.0, 1.0]])
-        A = artools.genStoichMat(rxns)
+        A = genStoichMat(rxns)
 
-        assert (artools.sameRows(stoich_mat, A) is True)
+        assert (sameRows(stoich_mat, A) is True)
 
 
     def test_UCG_1(self):
@@ -125,6 +125,6 @@ class TestRealistic:
                           [0, 0, 0, -1, -1, 1, 0, -1, 1],
                           [0, 0, 0, 1, 1, -1, -2, 3, -3],
                           [0, 0, 0, 0, 0, 0, 1, -1, 1]])
-        A = artools.genStoichMat(rxns)
+        A = genStoichMat(rxns)
 
-        assert (artools.sameRows(A, A_ref) is True)
+        assert (sameRows(A, A_ref) is True)

--- a/artools/test/genStoichMat_test.py
+++ b/artools/test/genStoichMat_test.py
@@ -5,6 +5,18 @@ import artools
 
 import scipy as sp
 
+class TestTuple:
+
+    def test_1(self):
+
+        rxn_str = ("A -> B",)
+
+        A = artools.genStoichMat(rxn_str)
+        A_ref = sp.array([[-1.0],
+                          [1.0]])
+
+        assert (artools.sameRows(A.T, A_ref.T) is True)
+
 
 class TestNormal:
 


### PR DESCRIPTION
The stoichiometric coefficient matrix is an important part of AR, but creating it (as a numpy 2-D array) is tiresome and error-prone because the coefficients need to be entered manually. `genStoichMat()` and associated functions help to generate this matrix from a more natural string format.

e.g `genStoichMat(['1.5*A + 0.35*B -> C + 4*D', 'A + D -> E'])` generates the matrix 
```
[[-1.5, -1.0],
 [-0.35, 0.0],
 [1.0, 0.0],
 [4.0, -1.0],
 [0.0, 1.0]]
```