### PR TITLE
Add syntax exception and more tests

### DIFF
--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1084,6 +1084,10 @@ def collectComponents(rxn_strings):
     all_components = {}
     comp_idx = 0
     for rxn_str in rxn_strings:
+
+        if not validRxnStr(rxn_str):
+            raise SyntaxError("Error in collectComponents(): Reaction string is not formatted correctly")
+
         # generate a list of single terms, e.g ['3*H2O', '1.5*H2', ...]
         terms = [term.strip() for side in rxn_str.split("->") for term in side.split("+")]
 
@@ -1096,6 +1100,33 @@ def collectComponents(rxn_strings):
                 comp_idx += 1
 
     return all_components
+
+
+def validRxnStr(rxn_str):
+    """
+    (work in progress)
+    Return True if rxn string is formatted correctly  according to the following
+    criteria:
+    1) Contains only one '->' per reaction
+    2) others??
+
+    Example:
+        In : validRxnStr('A + B')
+        Out: False
+
+        In : validRxnStr('A -> B -> C')
+        Out: False
+
+        In : validRxnStr('A -> 2*B')
+        Out: True
+    """
+
+    # conditions go here
+    if len(rxn_str.split("->")) != 2:
+        print "\nReaction string must contain only one '->' per reaction\n"
+        return False
+
+    return True
 
 
 def genStoichMat(rxn_strings):

--- a/artools/test/genStoichMat_test.py
+++ b/artools/test/genStoichMat_test.py
@@ -4,6 +4,7 @@ sys.path.append('../')
 from artools import genStoichMat, sameRows
 
 import scipy as sp
+import pytest
 
 
 def equivalentDictionaries(x, y):
@@ -187,3 +188,33 @@ class TestRealistic:
         A, d = genStoichMat(rxns)
 
         assert (sameRows(A, A_ref) and equivalentDictionaries(d, d_ref) is True)
+
+
+class TestWords:
+
+    def test_1(self):
+        rxns = ['ethylene + 0.5*oxygen -> ethylene_oxide',
+                'ethylene + 3*oxygen -> 2*carbon_dioxide + 2*water']
+
+        A_ref = sp.array([[-1. , -1. ],
+                          [-0.5, -3. ],
+                          [ 1. ,  0. ],
+                          [ 0. ,  2. ],
+                          [ 0. ,  2. ]])
+        d_ref = {'carbon_dioxide': 3,
+                 'ethylene': 0,
+                 'ethylene_oxide': 2,
+                 'oxygen': 1,
+                 'water': 4}
+
+        A, d = genStoichMat(rxns)
+
+        assert (sameRows(A, A_ref) and equivalentDictionaries(d, d_ref) is True)
+
+
+class TestErorr:
+
+    def test_double_arrow(self):
+        with pytest.raises(SyntaxError):
+            rxns = ['A -> B -> C']
+            genStoichMat(rxns)

--- a/artools/test/validRxnStr_test.py
+++ b/artools/test/validRxnStr_test.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+import sys
+sys.path.append('../')
+from artools import validRxnStr
+
+
+class TestNormal:
+
+    def test_1(self):
+        assert (validRxnStr('A -> B') is True)
+
+
+class TestMultiArrow:
+
+    def test_1(self):
+        assert (validRxnStr('A -> B -> C') is False)
+
+
+    def test_2(self):
+        assert (validRxnStr('A -> B -> C -> D') is False)
+
+
+class TestNoArrow:
+
+    def test_1(self):
+        assert (validRxnStr('A + B') is False)


### PR DESCRIPTION
`genStoichMat()` uses a special syntax, but there were no checks before to ensure that the format was correct.