### PR TITLE
Renamed calcDim() to ARDim()

### DIFF
--- a/artools/artools.py
+++ b/artools/artools.py
@@ -1037,7 +1037,7 @@ def cullPts(Xs, min_dist, axis_lims=None):
     return Vs
 
 
-def calcDim(Xs):
+def ARDim(Xs):
     """
     Compute the dimension of a set of point Xs that the AR will reside in.
     Note that is NOT the same as rank(Xs).
@@ -1048,14 +1048,14 @@ def calcDim(Xs):
         In : Xs = array([[ 1. ],
                          [ 0. ],
                          [ 0.5]])
-        In : calcDim(Xs)
+        In : ARDim(Xs)
         Out: 0
 
 
     Example
         In : Xs = array([[ 1.  ,  0.  ,  0.5 ],
                          [ 0.25, -0.25,  2.  ]])
-        In : calcDim(Xs)
+        In : ARDim(Xs)
         Out: 1
 
 
@@ -1064,7 +1064,7 @@ def calcDim(Xs):
                          [0.25, -0.25, 2.0],
                          [3.0, 2.0, 1.0],
                          [3.0, 2.0, 1.0]])
-        In : calcDim(Xs)
+        In : ARDim(Xs)
         Out: 2
     """
 

--- a/artools/test/ARDim_test.py
+++ b/artools/test/ARDim_test.py
@@ -1,6 +1,6 @@
 import sys
 sys.path.append('../')
-from artools import calcDim, stoichSubspace
+from artools import ARDim, stoichSubspace
 
 import scipy as sp
 
@@ -9,41 +9,41 @@ class TestZero:
 
     def test_1(self):
         x = sp.zeros([1, 3])
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
 
     def test_2(self):
         x = sp.zeros([1, 3]).T
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
 
     def test_3(self):
         x = sp.zeros([3, 3])
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
     def test_4(self):
         # row vector
         x = sp.array([[1.0, 2.0, 3.0, 4.0]])
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
 
     def test_5(self):
         # column vector
         x = sp.array([[1.0, 2.0, 3.0, 4.0]]).T
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
 
     def test_6(self):
         # 1-D numpy array
         x = sp.array([1.0, 2.0, 3.0, 4.0])
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
 
     def test_7(self):
         # repeated row
         x = sp.array([[1.0, 2.0],
                       [1.0, 2.0]])
-        assert (calcDim(x) == 0)
+        assert (ARDim(x) == 0)
 
 
 class Test1D:
@@ -53,7 +53,7 @@ class Test1D:
         Xs = sp.array([[0.0, 0.0],
                        [1.0, 1.0]])
 
-        assert (calcDim(Xs) == 1)
+        assert (ARDim(Xs) == 1)
 
 
     def test_2(self):
@@ -61,7 +61,7 @@ class Test1D:
         Xs = sp.array([[0.0, 0.0, 0.0],
                        [1.0, 1.0, 1.0]])
 
-        assert (calcDim(Xs) == 1)
+        assert (ARDim(Xs) == 1)
 
 
 class Test2D:
@@ -72,7 +72,7 @@ class Test2D:
                        [1.0, 1.0],
                        [1.0, 0.0]])
 
-        assert (calcDim(Xs) == 2)
+        assert (ARDim(Xs) == 2)
 
 
 class TestAR:
@@ -85,7 +85,7 @@ class TestAR:
 
         Vs = stoichSubspace(Cf0, stoich_mat)['all_Cs']
 
-        assert (calcDim(Vs) == 1)
+        assert (ARDim(Vs) == 1)
 
 
     def test_VDV_2D(self):
@@ -99,7 +99,7 @@ class TestAR:
 
         Vs = stoichSubspace(Cf0, stoich_mat)['all_Cs']
 
-        assert (calcDim(Vs) == 2)
+        assert (ARDim(Vs) == 2)
 
 
     def test_VDV_3D(self):
@@ -115,7 +115,7 @@ class TestAR:
 
         Vs = stoichSubspace(Cf0, stoich_mat)['all_Cs']
 
-        assert (calcDim(Vs) == 3)
+        assert (ARDim(Vs) == 3)
 
 
 class TestRand:
@@ -123,34 +123,34 @@ class TestRand:
     def test_0a(self):
 
         Xs = sp.rand(10, 1)
-        assert calcDim(Xs) == 0
+        assert ARDim(Xs) == 0
 
 
     def test_0b(self):
 
         Xs = sp.rand(1, 10)
-        assert calcDim(Xs) == 0
+        assert ARDim(Xs) == 0
 
 
     def test_1a(self):
 
         Xs = sp.rand(2, 3)
-        assert calcDim(Xs) == 1
+        assert ARDim(Xs) == 1
 
 
     def test_2(self):
 
         Xs = sp.rand(10, 2)
-        assert calcDim(Xs) == 2
+        assert ARDim(Xs) == 2
 
 
     def test_3(self):
 
         Xs = sp.rand(10, 3)
-        assert calcDim(Xs) == 3
+        assert ARDim(Xs) == 3
 
 
     def test_4(self):
 
         Xs = sp.rand(10, 4)
-        assert calcDim(Xs) == 4
+        assert ARDim(Xs) == 4


### PR DESCRIPTION
`calcDim()` as a function name is misleading because the function is actually calculating the dimension of the AR and not the rank. 

For example, if `A = numpy.[[1, 0, 0]].T`, then `calcDim(A)` would give zero, whereas the actual dimension of A is one (`rank(A)` = 1).